### PR TITLE
Shy/feature/lecture/plan

### DIFF
--- a/src/main/java/com/connect/oneboardserver/domain/lecture/Lecture.java
+++ b/src/main/java/com/connect/oneboardserver/domain/lecture/Lecture.java
@@ -25,20 +25,20 @@ public class Lecture {
     private String semester;
 
     @Column(length = 128)
-    private String lecturePlan;
+    private String lecturePlanUrl;
 
     @OneToMany(mappedBy = "lecture", cascade = CascadeType.REMOVE)
     private List<Notice> notices = new ArrayList<>();
 
     @Builder
-    public Lecture(String title, String semester, String lecturePlan, List<Notice> notices) {
+    public Lecture(String title, String semester, String lecturePlanUrl, List<Notice> notices) {
         this.title = title;
         this.semester = semester;
-        this.lecturePlan = lecturePlan;
+        this.lecturePlanUrl = lecturePlanUrl;
         this.notices = notices;
     }
 
-    public void updateLecturePlan(String lecturePlan) {
-        this.lecturePlan = lecturePlan;
+    public void updateLecturePlanUrl(String lecturePlanUrl) {
+        this.lecturePlanUrl = lecturePlanUrl;
     }
 }

--- a/src/main/java/com/connect/oneboardserver/service/lecture/PlanService.java
+++ b/src/main/java/com/connect/oneboardserver/service/lecture/PlanService.java
@@ -83,7 +83,7 @@ public class PlanService {
         }
     }
 
-    public ResponseEntity<Resource> loadLecturePlan(Long lectureId) {
+    public ResponseEntity<Resource> loadLecturePlan(Long lectureId) throws Exception {
         Lecture lecture = null;
         Resource resource = null;
         try {
@@ -97,7 +97,8 @@ public class PlanService {
                     .body(resource);
         } catch (Exception e) {
             e.printStackTrace();
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(resource);
+//            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(resource);
+            throw new Exception("Fail to load lecture plan : lectureId = " + lectureId);
         }
     }
 }

--- a/src/main/java/com/connect/oneboardserver/service/lecture/PlanService.java
+++ b/src/main/java/com/connect/oneboardserver/service/lecture/PlanService.java
@@ -31,26 +31,26 @@ public class PlanService {
         }
 
         Lecture lecture = null;
-        String uploadedFile = null;
+        String uploadedFilePath = null;
         try {
             lecture = lectureRepository.findById(lectureId).orElseThrow(Exception::new);
 
             // 강의계획서 파일이 있으면 파일 삭제
-            if(lecture.getLecturePlan() != null) {
-                if(storageService.delete(lecture.getLecturePlan())) {
-                    lecture.updateLecturePlan(null);
+            if(lecture.getLecturePlanUrl() != null) {
+                if(storageService.delete(lecture.getLecturePlanUrl())) {
+                    lecture.updateLecturePlanUrl(null);
                 }
             }
 
             String path = "/lecture_" + lectureId + "/plan";
-            uploadedFile = storageService.store(path, file);
+            uploadedFilePath = storageService.store(path, file);
 
         } catch (Exception e) {
             e.printStackTrace();
             return new ResponseDto("FAIL");
         }
 
-        lecture.updateLecturePlan(uploadedFile);
+        lecture.updateLecturePlanUrl(uploadedFilePath);
 
         PlanUploadResponseDto responseDto = PlanUploadResponseDto.builder()
                 .lectureId(lecture.getId())
@@ -66,10 +66,10 @@ public class PlanService {
         try {
             lecture = lectureRepository.findById(lectureId).orElseThrow(Exception::new);
 
-            if(lecture.getLecturePlan() != null) {
-                System.out.println(lecture.getLecturePlan());
-                if(storageService.delete(lecture.getLecturePlan())) {
-                    lecture.updateLecturePlan(null);
+            if(lecture.getLecturePlanUrl() != null) {
+                System.out.println(lecture.getLecturePlanUrl());
+                if(storageService.delete(lecture.getLecturePlanUrl())) {
+                    lecture.updateLecturePlanUrl(null);
                     return new ResponseDto("SUCCESS");
                 } else {
                     throw new Exception("No file to delete");
@@ -88,7 +88,7 @@ public class PlanService {
         Resource resource = null;
         try {
             lecture = lectureRepository.findById(lectureId).orElseThrow(Exception::new);
-            String filePath = lecture.getLecturePlan();
+            String filePath = lecture.getLecturePlanUrl();
             resource = storageService.load(filePath);
             String contentDisposition = "attachment; filename=\"" +
                     lecture.getTitle() + "_plan" + filePath.substring(filePath.lastIndexOf(".")) + "\"";

--- a/src/main/java/com/connect/oneboardserver/service/lecture/PlanService.java
+++ b/src/main/java/com/connect/oneboardserver/service/lecture/PlanService.java
@@ -91,7 +91,7 @@ public class PlanService {
             String filePath = lecture.getLecturePlan();
             resource = storageService.load(filePath);
             String contentDisposition = "attachment; filename=\"" +
-                    lecture.getTitle() + "_plan\"";
+                    lecture.getTitle() + "_plan" + filePath.substring(filePath.lastIndexOf(".")) + "\"";
             return ResponseEntity.ok()
                     .header(HttpHeaders.CONTENT_DISPOSITION, contentDisposition)
                     .body(resource);

--- a/src/main/java/com/connect/oneboardserver/web/dto/lecture/LectureFindAllResponseDto.java
+++ b/src/main/java/com/connect/oneboardserver/web/dto/lecture/LectureFindAllResponseDto.java
@@ -12,14 +12,14 @@ public class LectureFindAllResponseDto {
     private Long id;
     private String title;
     private String semester;
-    private String lecturePlan;
+    private String lecturePlanUrl;
 
     @Builder
-    public LectureFindAllResponseDto(Long id, String title, String semester, String lecturePlan) {
+    public LectureFindAllResponseDto(Long id, String title, String semester, String lecturePlanUrl) {
         this.id = id;
         this.title = title;
         this.semester = semester;
-        this.lecturePlan = lecturePlan;
+        this.lecturePlanUrl = lecturePlanUrl;
     }
 
     public static LectureFindAllResponseDto toResponseDto(Lecture entity) {
@@ -27,7 +27,7 @@ public class LectureFindAllResponseDto {
                 .id(entity.getId())
                 .title(entity.getTitle())
                 .semester(entity.getSemester())
-                .lecturePlan(entity.getLecturePlan())
+                .lecturePlanUrl(entity.getLecturePlanUrl())
                 .build();
     }
 }

--- a/src/main/java/com/connect/oneboardserver/web/dto/lecture/LectureFindResponseDto.java
+++ b/src/main/java/com/connect/oneboardserver/web/dto/lecture/LectureFindResponseDto.java
@@ -12,15 +12,13 @@ public class LectureFindResponseDto {
     private Long id;
     private String title;
     private String semester;
-    private String lecturePlan;
     private String professor;
 
     @Builder
-    public LectureFindResponseDto(Long id, String title, String semester, String lecturePlan, String professor) {
+    public LectureFindResponseDto(Long id, String title, String semester, String professor) {
         this.id = id;
         this.title = title;
         this.semester = semester;
-        this.lecturePlan = lecturePlan;
         this.professor = professor;
     }
 
@@ -29,7 +27,6 @@ public class LectureFindResponseDto {
                 .id(entity.getId())
                 .title(entity.getTitle())
                 .semester(entity.getSemester())
-                .lecturePlan(entity.getLecturePlan())
                 .build();
     }
 

--- a/src/main/java/com/connect/oneboardserver/web/lecture/PlanApiController.java
+++ b/src/main/java/com/connect/oneboardserver/web/lecture/PlanApiController.java
@@ -29,7 +29,7 @@ public class PlanApiController {
 
     // 과목 강의계획서 로드
     @GetMapping("/lecture/{lectureId}/plan")
-    public ResponseEntity<Resource> loadLecturePlan(@PathVariable Long lectureId) {
+    public ResponseEntity<Resource> loadLecturePlan(@PathVariable Long lectureId) throws Exception {
         return planService.loadLecturePlan(lectureId);
     }
 

--- a/src/test/java/com/connect/oneboardserver/domain/assignment/AssignmentRepositoryTest.java
+++ b/src/test/java/com/connect/oneboardserver/domain/assignment/AssignmentRepositoryTest.java
@@ -38,12 +38,12 @@ public class AssignmentRepositoryTest {
     public void createAssignment() {
         //given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = lectureRepository.save(Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build());
 

--- a/src/test/java/com/connect/oneboardserver/domain/lecture/LectureRepositoryTest.java
+++ b/src/test/java/com/connect/oneboardserver/domain/lecture/LectureRepositoryTest.java
@@ -29,12 +29,12 @@ public class LectureRepositoryTest {
     public void createLecture() {
         // given
         String title = "test_lecture_1";
-        String lecturePlan = "test_url";
+        String lecturePlanUrl = "test_url";
         String semester = "2021-2";
 
         lectureRepository.save(Lecture.builder()
                 .title(title)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build());
 

--- a/src/test/java/com/connect/oneboardserver/domain/lecture/NoticeRepositoryTest.java
+++ b/src/test/java/com/connect/oneboardserver/domain/lecture/NoticeRepositoryTest.java
@@ -39,12 +39,12 @@ public class NoticeRepositoryTest {
     public void createNotice() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = lectureRepository.save(Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build());
 
@@ -76,13 +76,13 @@ public class NoticeRepositoryTest {
         // given
         Lecture lecture1 = lectureRepository.save(Lecture.builder()
                 .title("title1")
-                .lecturePlan("plan1")
+                .lecturePlanUrl("plan1")
                 .semester("semester1")
                 .build());
 
         Lecture lecture2 = lectureRepository.save(Lecture.builder()
                 .title("title2")
-                .lecturePlan("plan2")
+                .lecturePlanUrl("plan2")
                 .semester("semester2")
                 .build());
 

--- a/src/test/java/com/connect/oneboardserver/web/lecture/LessonApiControllerTest.java
+++ b/src/test/java/com/connect/oneboardserver/web/lecture/LessonApiControllerTest.java
@@ -49,12 +49,12 @@ public class LessonApiControllerTest {
     public void requestCreateLesson() {
         // given
         String lectureTitle = "lecture";
-        String lecturePlan = "url";
+        String lecturePlanUrl = "url";
         String semester = "2021-2";
 
         Long lectureId = lectureRepository.save(Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build()).getId();
 
@@ -109,12 +109,12 @@ public class LessonApiControllerTest {
     void requestFindLesson() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = lectureRepository.save(Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build());
 
@@ -165,12 +165,12 @@ public class LessonApiControllerTest {
     void requestDeleteLesson() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build();
 
@@ -207,12 +207,12 @@ public class LessonApiControllerTest {
     void requestUpdateLesson() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build();
 

--- a/src/test/java/com/connect/oneboardserver/web/lecture/NoticeApiControllerTest.java
+++ b/src/test/java/com/connect/oneboardserver/web/lecture/NoticeApiControllerTest.java
@@ -50,12 +50,12 @@ public class NoticeApiControllerTest {
     void requestCreateNotice() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Long lectureId = lectureRepository.save(Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build()).getId();
 
@@ -96,12 +96,12 @@ public class NoticeApiControllerTest {
     void requestFindNotice() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build();
 
@@ -145,12 +145,12 @@ public class NoticeApiControllerTest {
     void requestUpdateNotice() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build();
 
@@ -205,12 +205,12 @@ public class NoticeApiControllerTest {
     void requestDeleteNotice() {
         // given
         String lectureTitle = "test lecture";
-        String lecturePlan = "test url";
+        String lecturePlanUrl = "test url";
         String semester = "2021-2";
 
         Lecture lecture = Lecture.builder()
                 .title(lectureTitle)
-                .lecturePlan(lecturePlan)
+                .lecturePlanUrl(lecturePlanUrl)
                 .semester(semester)
                 .build();
 


### PR DESCRIPTION
### 기능
- 강의계획서 파일 다운로드 시 파일 이름에 확장자 추가
- 강의계획서 파일 다운로드 실패 시 Fail Response 반환하도록 수정 (기존에는 404 반환)
- 과목 정보, 목록 요청 응답 데이터에서 lecturePlanUrl 제외

### 특이사항
- Lecture Entity의 필드명 수정
    - lecturePlan -> lecturePlanUrl

### 변경된 API 목록
```
GET /lecture/{lectureId}/plan
GET /lectures
GET /lecture/{lectureId}
```